### PR TITLE
Add comprehensive tests for Tailscale role

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,9 @@ test-debian: ## Run debian role test with purge functionality
 test-ssh: ## Run SSH role test with comprehensive security validation
 	ansible-playbook tests/playbooks/debian12-ssh.yml
 
+test-tailscale: ## Run Tailscale role test with CLI and service validation
+	ansible-playbook tests/playbooks/debian12-tailscale.yml
+
 .PHONY: clean
 clean: ## Clean up the build artifacts, object files, executables, and any other generated files
 	rm -rf *.tar.gz

--- a/tests/playbooks/debian12-tailscale.yml
+++ b/tests/playbooks/debian12-tailscale.yml
@@ -1,0 +1,389 @@
+---
+# Test Playbook: Tailscale Role Comprehensive Testing
+# This playbook comprehensively tests the Tailscale role including:
+# - Prerequisites validation (Debian 12, architecture)
+# - Package installation and CLI tool availability
+# - Service management (tailscaled daemon)
+# - CLI commands and configuration validation
+# - Metadata handling and file operations
+# NOTE: This test does NOT attempt actual Tailscale network connections
+
+- name: Test Tailscale Role - Phase 1 (Prerequisites and Installation)
+  hosts: debian12
+  connection: ssh
+  gather_facts: true
+  become: true
+  vars:
+    tailscale_install: true
+    tailscale_authkey: ""  # Empty to avoid actual login attempts
+    tailscale_login_server: ""
+    tailscale_advertise_exit_node: ""
+    tailscale_accept_dns: ""
+    tailscale_accept_routes: ""
+
+  tasks:
+    - name: Phase 1 | Create test metadata directory
+      ansible.builtin.file:
+        path: /var/lib/instance-metadata
+        state: directory
+        mode: "0755"
+        owner: root
+        group: root
+
+    - name: Phase 1 | Create test hostname metadata
+      ansible.builtin.copy:
+        content: "test-tailscale-host"
+        dest: /var/lib/instance-metadata/hostname
+        mode: "0644"
+        owner: root
+        group: root
+
+    - name: Phase 1 | Check initial state - tailscale command availability
+      ansible.builtin.command: which tailscale
+      register: tailscale_initial_check
+      failed_when: false
+      changed_when: false
+
+    - name: Phase 1 | Display initial tailscale availability
+      ansible.builtin.debug:
+        msg: "Initial tailscale availability: {{ 'available' if tailscale_initial_check.rc == 0 else 'not available' }}"
+
+    - name: Phase 1 | Apply Tailscale Role (Installation)
+      ansible.builtin.include_role:
+        name: tailscale
+
+    - name: Phase 1 | Verify tailscale CLI tool is installed
+      ansible.builtin.command: which tailscale
+      register: tailscale_which
+      changed_when: false
+
+    - name: Phase 1 | Assert tailscale CLI is available
+      ansible.builtin.assert:
+        that:
+          - tailscale_which.rc == 0
+          - "'tailscale' in tailscale_which.stdout"
+        fail_msg: "tailscale CLI tool is not available"
+        success_msg: "tailscale CLI tool installed successfully"
+
+    - name: Phase 1 | Test tailscale version command
+      ansible.builtin.command: tailscale version
+      register: tailscale_version
+      changed_when: false
+
+    - name: Phase 1 | Validate tailscale version output
+      ansible.builtin.assert:
+        that:
+          - tailscale_version.rc == 0
+          - "'1.84.0' in tailscale_version.stdout"
+        fail_msg: "tailscale version command failed or unexpected version"
+        success_msg: "tailscale version command successful"
+
+    - name: Phase 1 | Verify package installation via dpkg
+      ansible.builtin.command: dpkg -l tailscale
+      register: tailscale_dpkg
+      changed_when: false
+
+    - name: Phase 1 | Assert package is properly installed
+      ansible.builtin.assert:
+        that:
+          - tailscale_dpkg.rc == 0
+          - "'ii  tailscale' in tailscale_dpkg.stdout"
+        fail_msg: "tailscale package not properly installed"
+        success_msg: "tailscale package installation verified"
+
+    - name: Phase 1 | Display installation results
+      ansible.builtin.debug:
+        msg: "Phase 1 Complete: Tailscale installation and CLI availability verified"
+
+- name: Test Tailscale Role - Phase 2 (Service Management)
+  hosts: debian12
+  connection: ssh
+  gather_facts: true
+  become: true
+
+  tasks:
+    - name: Phase 2 | Check tailscaled service status
+      ansible.builtin.systemd_service:
+        name: tailscaled
+        state: started
+      check_mode: true
+      register: tailscaled_status
+      failed_when: false
+
+    - name: Phase 2 | Verify tailscaled service is enabled
+      ansible.builtin.systemd_service:
+        name: tailscaled
+        enabled: true
+      check_mode: true
+      register: tailscaled_enabled_check
+
+    - name: Phase 2 | Assert tailscaled service configuration
+      ansible.builtin.assert:
+        that:
+          - tailscaled_enabled_check.enabled == true
+        fail_msg: "tailscaled service is not enabled"
+        success_msg: "tailscaled service is properly enabled"
+
+    - name: Phase 2 | Start tailscaled service for testing
+      ansible.builtin.systemd_service:
+        name: tailscaled
+        state: started
+
+    - name: Phase 2 | Wait for tailscaled socket creation
+      ansible.builtin.wait_for:
+        path: /run/tailscale/tailscaled.sock
+        state: present
+        timeout: 30
+
+    - name: Phase 2 | Verify socket file exists and permissions
+      ansible.builtin.stat:
+        path: /run/tailscale/tailscaled.sock
+      register: tailscale_socket_stat
+
+    - name: Phase 2 | Assert socket file properties
+      ansible.builtin.assert:
+        that:
+          - tailscale_socket_stat.stat.exists
+          - tailscale_socket_stat.stat.issock
+        fail_msg: "tailscaled socket file is missing or incorrect type"
+        success_msg: "tailscaled socket file verified"
+
+    - name: Phase 2 | Test service restart capability
+      ansible.builtin.systemd_service:
+        name: tailscaled
+        state: restarted
+
+    - name: Phase 2 | Verify service is running after restart
+      ansible.builtin.systemd_service:
+        name: tailscaled
+        state: started
+      check_mode: true
+      register: tailscaled_post_restart
+
+    - name: Phase 2 | Assert service survived restart
+      ansible.builtin.assert:
+        that:
+          - tailscaled_post_restart.status.ActiveState == "active"
+        fail_msg: "tailscaled service failed to restart properly"
+        success_msg: "tailscaled service restart successful"
+
+    - name: Phase 2 | Display service management results
+      ansible.builtin.debug:
+        msg: "Phase 2 Complete: Tailscale service management verified"
+
+- name: Test Tailscale Role - Phase 3 (CLI Commands and Configuration)
+  hosts: debian12
+  connection: ssh
+  gather_facts: true  
+  become: true
+
+  tasks:
+    - name: Phase 3 | Test tailscale help command
+      ansible.builtin.command: tailscale --help
+      register: tailscale_help
+      changed_when: false
+
+    - name: Phase 3 | Validate help command output
+      ansible.builtin.assert:
+        that:
+          - tailscale_help.rc == 0
+          - "'Usage:' in tailscale_help.stdout"
+          - "'status' in tailscale_help.stdout"
+        fail_msg: "tailscale help command failed or missing expected content"
+        success_msg: "tailscale help command verified"
+
+    - name: Phase 3 | Test tailscale status command (expect NeedsLogin)
+      ansible.builtin.command: tailscale --socket=/run/tailscale/tailscaled.sock status --json
+      register: tailscale_status
+      changed_when: false
+      failed_when: false
+
+    - name: Phase 3 | Parse tailscale status JSON
+      ansible.builtin.set_fact:
+        tailscale_status_json: "{{ tailscale_status.stdout | from_json }}"
+      when: tailscale_status.rc == 0
+
+    - name: Phase 3 | Validate status command structure
+      ansible.builtin.assert:
+        that:
+          - tailscale_status.rc == 0
+          - tailscale_status_json is defined
+          - "'BackendState' in tailscale_status_json"
+        fail_msg: "tailscale status command failed or invalid JSON structure"
+        success_msg: "tailscale status command and JSON parsing verified"
+
+    - name: Phase 3 | Test tailscale logout command (should handle gracefully)
+      ansible.builtin.command: tailscale --socket=/run/tailscale/tailscaled.sock logout
+      register: tailscale_logout
+      changed_when: false
+      failed_when: false
+
+    - name: Phase 3 | Validate logout command handling
+      ansible.builtin.assert:
+        that:
+          - tailscale_logout.rc in [0, 1]  # Success or expected failure
+        fail_msg: "tailscale logout command had unexpected error"
+        success_msg: "tailscale logout command handled correctly"
+
+    - name: Phase 3 | Test invalid tailscale command handling
+      ansible.builtin.command: tailscale --socket=/run/tailscale/tailscaled.sock invalid-command
+      register: tailscale_invalid
+      changed_when: false
+      failed_when: false
+
+    - name: Phase 3 | Validate error handling
+      ansible.builtin.assert:
+        that:
+          - tailscale_invalid.rc != 0
+        fail_msg: "tailscale should reject invalid commands"
+        success_msg: "tailscale invalid command handling verified"
+
+    - name: Phase 3 | Test tailscale ip command (without login)
+      ansible.builtin.command: tailscale ip
+      register: tailscale_ip
+      changed_when: false
+      failed_when: false
+
+    - name: Phase 3 | Validate IP command behavior when not logged in
+      ansible.builtin.assert:
+        that:
+          - tailscale_ip.rc != 0 or tailscale_ip.stdout == ""
+        fail_msg: "tailscale ip command should fail or return empty when not logged in"
+        success_msg: "tailscale ip command behavior verified"
+
+    - name: Phase 3 | Display CLI testing results
+      ansible.builtin.debug:
+        msg: "Phase 3 Complete: Tailscale CLI commands and configuration validation successful"
+
+- name: Test Tailscale Role - Phase 4 (Metadata and File Operations)
+  hosts: debian12
+  connection: ssh
+  gather_facts: true
+  become: true
+  vars:
+    tailscale_install: true
+    tailscale_authkey: "tskey-test-key-for-validation-only"  # Test key for metadata testing
+
+  tasks:
+    - name: Phase 4 | Apply Tailscale role with test auth key for metadata testing
+      ansible.builtin.include_role:
+        name: tailscale
+
+    - name: Phase 4 | Verify metadata directory exists
+      ansible.builtin.stat:
+        path: /var/lib/instance-metadata
+      register: metadata_dir_stat
+
+    - name: Phase 4 | Assert metadata directory properties
+      ansible.builtin.assert:
+        that:
+          - metadata_dir_stat.stat.exists
+          - metadata_dir_stat.stat.isdir
+          - metadata_dir_stat.stat.mode == '0755'
+        fail_msg: "metadata directory missing or incorrect permissions"
+        success_msg: "metadata directory verified"
+
+    - name: Phase 4 | Check if auth key was saved
+      ansible.builtin.stat:
+        path: /var/lib/instance-metadata/tailscale-authkey
+      register: authkey_stat
+
+    - name: Phase 4 | Verify auth key file properties
+      ansible.builtin.assert:
+        that:
+          - authkey_stat.stat.exists
+          - authkey_stat.stat.mode == '0400'
+          - authkey_stat.stat.pw_name == 'root'
+          - authkey_stat.stat.gr_name == 'root'
+        fail_msg: "tailscale auth key file missing or incorrect permissions"
+        success_msg: "tailscale auth key file permissions verified"
+
+    - name: Phase 4 | Read auth key content
+      ansible.builtin.slurp:
+        src: /var/lib/instance-metadata/tailscale-authkey
+      register: stored_authkey
+
+    - name: Phase 4 | Validate stored auth key content
+      ansible.builtin.assert:
+        that:
+          - (stored_authkey.content | b64decode | trim) == "tskey-test-key-for-validation-only"
+        fail_msg: "stored auth key content doesn't match expected value"
+        success_msg: "auth key storage and retrieval verified"
+
+    - name: Phase 4 | Check hostname metadata
+      ansible.builtin.stat:
+        path: /var/lib/instance-metadata/hostname
+      register: hostname_stat
+
+    - name: Phase 4 | Verify hostname metadata exists
+      ansible.builtin.assert:
+        that:
+          - hostname_stat.stat.exists
+          - hostname_stat.stat.mode == '0644'
+        fail_msg: "hostname metadata file missing or incorrect permissions"
+        success_msg: "hostname metadata file verified"
+
+    - name: Phase 4 | Test role idempotency - run again
+      ansible.builtin.include_role:
+        name: tailscale
+
+    - name: Phase 4 | Verify auth key still exists after second run
+      ansible.builtin.stat:
+        path: /var/lib/instance-metadata/tailscale-authkey
+      register: authkey_idempotent_stat
+
+    - name: Phase 4 | Assert idempotency
+      ansible.builtin.assert:
+        that:
+          - authkey_idempotent_stat.stat.exists
+          - authkey_idempotent_stat.stat.mode == '0400'
+        fail_msg: "role is not idempotent - auth key file changed"
+        success_msg: "role idempotency verified"
+
+    - name: Phase 4 | Clean up test auth key
+      ansible.builtin.file:
+        path: /var/lib/instance-metadata/tailscale-authkey
+        state: absent
+
+    - name: Phase 4 | Stop tailscaled service for cleanup
+      ansible.builtin.systemd_service:
+        name: tailscaled
+        state: stopped
+
+    - name: Phase 4 | Final service status check
+      ansible.builtin.systemd_service:
+        name: tailscaled
+        state: stopped
+      check_mode: true
+      register: final_service_status
+
+    - name: Phase 4 | Assert final service state
+      ansible.builtin.assert:
+        that:
+          - final_service_status.status.ActiveState == "inactive"
+        fail_msg: "tailscaled service is not properly stopped"
+        success_msg: "tailscaled service cleanup verified"
+
+    - name: Phase 4 | Test Summary
+      ansible.builtin.debug:
+        msg: |
+          ===========================================
+          TAILSCALE ROLE TEST SUMMARY
+          ===========================================
+          
+          Status: ALL TESTS PASSED
+          - Prerequisites validation: ✓
+          - Package installation: ✓
+          - CLI tool availability: ✓
+          - Service management: ✓
+          - Socket communication: ✓
+          - CLI commands: ✓
+          - Error handling: ✓
+          - Metadata operations: ✓
+          - File permissions: ✓
+          - Role idempotency: ✓
+          - Cleanup: ✓
+          ===========================================
+
+          Note: Network connectivity tests were not performed
+          as requested - only CLI functionality was validated.


### PR DESCRIPTION
## Summary
- Implements comprehensive 4-phase testing for the Tailscale role
- Adds `test-tailscale` target to Makefile for easy test execution
- Focuses on CLI functionality and service validation without network connections

## Test Coverage
- **Phase 1**: Prerequisites validation and package installation
- **Phase 2**: Service management (tailscaled daemon, socket creation)
- **Phase 3**: CLI commands and configuration validation
- **Phase 4**: Metadata operations and file permissions

## Key Features
- Tests CLI tool availability and version validation
- Validates service enablement, startup, and restart capabilities
- Verifies socket communication and JSON status parsing
- Tests metadata storage with proper file permissions (0400 for auth keys)
- Includes error handling and invalid command scenarios
- Ensures role idempotency and proper cleanup

## Test Execution
```bash
make test-tailscale
```

## Notes
- No actual Tailscale network connections are attempted
- Tests focus on CLI functionality and local service management
- Follows same 4-phase testing pattern as SSH role tests

🤖 Generated with [Claude Code](https://claude.ai/code)