### PR TITLE
fix: Implement proper environment variable fallback for Debian topology

### DIFF
--- a/playbooks/standard-debian.yml
+++ b/playbooks/standard-debian.yml
@@ -30,8 +30,8 @@
         debian_minimal: "{{ minimal | default(m) | default(lookup('env', 'DEBIAN_MINIMAL') | default('false') | bool) }}"
         debian_prune: "{{ prune | default(p) | default(lookup('env', 'DEBIAN_PRUNE') | default('false') | bool) }}"
         debian_hostname: "{{ hostname | default(lookup('env', 'DEBIAN_HOSTNAME')) | default(omit) }}"
-        metadata_topology_region: "{{ topology_region | default(omit) }}"
-        metadata_topology_zone: "{{ topology_zone | default(omit) }}"
+        metadata_topology_region: "{{ topology_region | default(lookup('env', 'DEBIAN_TOPOLOGY_REGION')) | default('') | lower }}"
+        metadata_topology_zone: "{{ topology_zone | default(lookup('env', 'DEBIAN_TOPOLOGY_ZONE')) | default('') | lower }}"
 
     - name: Include Role
       ansible.builtin.include_role:


### PR DESCRIPTION
## Summary
• Fix environment variable fallback chain in standard-debian.yml for topology variables
• Implement proper metadata system pattern: playbook arg → environment variable → default value
• Align with documented DEBIAN_TOPOLOGY_REGION and DEBIAN_TOPOLOGY_ZONE variables
• Follow established pattern used in other playbooks like standard-kubernetes.yml

## Changes
- Updated `metadata_topology_region` and `metadata_topology_zone` variables in standard-debian.yml
- Added proper lookup for DEBIAN_TOPOLOGY_REGION and DEBIAN_TOPOLOGY_ZONE environment variables
- Applied lower case transformation for consistency

## Test plan
- [ ] Verify playbook runs without environment variables (uses empty defaults)
- [ ] Test with DEBIAN_TOPOLOGY_REGION and DEBIAN_TOPOLOGY_ZONE set
- [ ] Confirm topology variables are passed correctly to debian role
- [ ] Run make lint to ensure no syntax issues

🤖 Generated with [Claude Code](https://claude.ai/code)