### PR TITLE
Fix: Replace cron-based transparent hugepages with systemd service

### DIFF
--- a/roles/debian/tasks/500-post-configuration.yml
+++ b/roles/debian/tasks/500-post-configuration.yml
@@ -36,12 +36,34 @@
         name: system-cpu-governor
         state: started
 
-- name: Debian > Kernel > Disable Transparent Hugepages
-  ansible.builtin.cron:
-    name: "Disable Transparent Hugepages"
-    special_time: reboot
-    job: >-
-      echo 'madvise' | sudo tee /sys/kernel/mm/transparent_hugepage/enabled
+- name: Debian > Kernel > Disable Transparent Hugepages > Create systemd service
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/disable-transparent-hugepages.service
+    content: |
+      [Unit]
+      Description=Disable Transparent Hugepages
+      After=multi-user.target
+
+      [Service]
+      Type=oneshot
+      ExecStart=/bin/sh -c 'echo madvise | tee /sys/kernel/mm/transparent_hugepage/enabled'
+      RemainAfterExit=yes
+
+      [Install]
+      WantedBy=multi-user.target
+    mode: "0644"
+  register: debian__thp_service
+
+- name: Debian > Kernel > Disable Transparent Hugepages > Enable systemd service
+  ansible.builtin.systemd_service:
+    name: disable-transparent-hugepages
+    enabled: true
+    daemon_reload: "{{ debian__thp_service.changed }}"
+
+- name: Debian > Kernel > Disable Transparent Hugepages > Start systemd service
+  ansible.builtin.systemd_service:
+    name: disable-transparent-hugepages
+    state: started
 
 - name: Debian > Network > Enable systemd-networkd.service
   when: not (ansible_virtualization_type is defined and ansible_virtualization_type == "VMware")


### PR DESCRIPTION
## Summary
- Fixes "crontab executable not found" error in debian role
- Replaces unreliable cron-based approach with robust systemd service
- Maintains same functionality while improving reliability

## Root Cause
The transparent hugepages task was failing because:
- Used `ansible.builtin.cron` module which depends on `crontab` executable
- Cron service wasn't properly available during task execution
- Created dependency issues in the role execution order

## Solution
Replaced cron-based implementation with systemd service approach:
- Creates `/etc/systemd/system/disable-transparent-hugepages.service`
- Uses consistent pattern matching existing CPU governor implementation
- Provides better error handling and logging
- Ensures service runs at boot and is immediately available

## Changes
- `roles/debian/tasks/500-post-configuration.yml`: Replace 5-line cron task with 3-task systemd service implementation
- Maintains same kernel configuration: `echo madvise > /sys/kernel/mm/transparent_hugepage/enabled`
- Follows established patterns in the same file

## Test Results
✅ Full debian role test suite passes (all 4 phases)
✅ Systemd service created, enabled, and started successfully
✅ No regression in existing functionality
✅ Package installation/purge cycles work correctly

## Benefits
- **Reliability**: No dependency on crontab executable
- **Consistency**: Matches existing systemd service patterns
- **Better error handling**: Systemd provides superior logging
- **Immediate effect**: Service starts immediately and persists across reboots

🤖 Generated with [Claude Code](https://claude.ai/code)