### PR TITLE
Standardize kubernetes metadata variables with kubernetes-* prefix

### DIFF
--- a/roles/debian/tasks/500-post-configuration.yml
+++ b/roles/debian/tasks/500-post-configuration.yml
@@ -79,7 +79,7 @@
   failed_when: false
 
 - name: Debian > Network > Disable networking.service
-  when: 
+  when:
     - not (ansible_virtualization_type is defined and ansible_virtualization_type == "VMware")
     - networking_service_status.status is defined
     - networking_service_status.status.LoadState != "not-found"

--- a/roles/kubernetes/defaults/main.yml
+++ b/roles/kubernetes/defaults/main.yml
@@ -15,7 +15,7 @@ kubernetes_join_token: >-
   {{
     (
       lookup('env', 'KUBERNETES_JOIN_TOKEN') or
-      lookup('file', '/var/lib/instance-metadata/auth/kubernetes-join-token', errors='ignore') or
+      lookup('file', '/var/lib/instance-metadata/kubernetes-join-token', errors='ignore') or
       ''
     ) | trim
   }}
@@ -24,7 +24,7 @@ kubernetes_join_discovery_hash: >-
   {{
     (
       lookup('env', 'KUBERNETES_JOIN_DISCOVERY_HASH') or
-      lookup('file', '/var/lib/instance-metadata/auth/kubernetes-join-discovery-hash', errors='ignore') or
+      lookup('file', '/var/lib/instance-metadata/kubernetes-join-discovery-hash', errors='ignore') or
       ''
     ) | trim
   }}
@@ -42,7 +42,7 @@ kubernetes_join_certificate_key: >-
   {{
     (
       lookup('env', 'KUBERNETES_JOIN_CERTIFICATE_KEY') or
-      lookup('file', '/var/lib/instance-metadata/auth/kubernetes-join-certificate-key', errors='ignore') or
+      lookup('file', '/var/lib/instance-metadata/kubernetes-join-certificate-key', errors='ignore') or
       ''
     ) | trim
   }}

--- a/roles/kubernetes/tasks/999-metadata.yml
+++ b/roles/kubernetes/tasks/999-metadata.yml
@@ -7,13 +7,6 @@
     group: root
     mode: '0755'
 
-- name: "Metadata > Kubernetes > Create auth directory"
-  ansible.builtin.file:
-    path: /var/lib/instance-metadata/auth
-    state: directory
-    owner: root
-    group: root
-    mode: '0500'
 
 - name: "Metadata > Kubernetes > Store kubernetes role"
   ansible.builtin.copy:
@@ -57,7 +50,7 @@
 - name: "Metadata > Kubernetes > Store bootstrap token"
   ansible.builtin.copy:
     content: "{{ new_bootstrap_token_result.stdout | default(bootstrap_token_result.stdout) }}"
-    dest: /var/lib/instance-metadata/auth/kubernetes-join-token
+    dest: /var/lib/instance-metadata/kubernetes-join-token
     owner: root
     group: root
     mode: '0400'
@@ -80,7 +73,7 @@
 - name: "Metadata > Kubernetes > Store discovery token CA cert hash"
   ansible.builtin.copy:
     content: "sha256:{{ discovery_hash_result.stdout }}"
-    dest: /var/lib/instance-metadata/auth/kubernetes-join-discovery-hash
+    dest: /var/lib/instance-metadata/kubernetes-join-discovery-hash
     owner: root
     group: root
     mode: '0400'
@@ -103,7 +96,7 @@
 - name: "Metadata > Kubernetes > Store certificate key"
   ansible.builtin.copy:
     content: "{{ certificate_key_result.stdout }}"
-    dest: /var/lib/instance-metadata/auth/kubernetes-join-certificate-key
+    dest: /var/lib/instance-metadata/kubernetes-join-certificate-key
     owner: root
     group: root
     mode: '0400'


### PR DESCRIPTION
## Summary
- Standardized kubernetes metadata variable naming to use consistent `kubernetes-*` prefix
- Moved join credentials from `/auth/` subdirectory to root metadata level for better discoverability
- Maintained security with `0400` file permissions for sensitive credentials
- Fixed lint compliance issue in debian role

## Changes
**Metadata file path changes:**
- `/var/lib/instance-metadata/auth/kubernetes-join-token` → `/var/lib/instance-metadata/kubernetes-join-token`
- `/var/lib/instance-metadata/auth/kubernetes-join-discovery-hash` → `/var/lib/instance-metadata/kubernetes-join-discovery-hash`
- `/var/lib/instance-metadata/auth/kubernetes-join-certificate-key` → `/var/lib/instance-metadata/kubernetes-join-certificate-key`

**Files modified:**
- `roles/kubernetes/defaults/main.yml` - Updated metadata file lookup paths
- `roles/kubernetes/tasks/999-metadata.yml` - Updated destination paths and removed auth directory creation
- `roles/debian/tasks/500-post-configuration.yml` - Fixed trailing spaces for lint compliance

## Test plan
- [x] Syntax validation passed for kubernetes role
- [x] Ansible-lint validation completed
- [ ] Run kubernetes role tests to verify functionality: `make test-ansible-role-kubernetes`
- [ ] Verify metadata files are created with correct paths and permissions

🤖 Generated with [Claude Code](https://claude.ai/code)